### PR TITLE
Fully automate dev setup with Gitpod

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,30 @@
+FROM gitpod/workspace-full
+
+# Install custom tools, runtimes, etc.
+# For example "bastet", a command-line tetris clone:
+# RUN brew install bastet
+#
+# More information: https://www.gitpod.io/docs/config-docker/
+
+# be root
+USER root
+
+# update things
+RUN apt-get update -qqy && apt-get upgrade -qqy
+
+# install google-cloud-sdk
+ENV PATH "$PATH:/opt/google-cloud-sdk/bin/"
+RUN apt-get -qqy update && apt-get -qqy install \
+      apt-transport-https \
+      ca-certificates \
+      curl \
+      gnupg && \
+    echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" \
+      | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
+    curl https://packages.cloud.google.com/apt/doc/apt-key.gpg \
+      | sudo apt-key --keyring /usr/share/keyrings/cloud.google.gpg add - && \
+    apt-get -qqy update && apt-get -qqy install \
+      google-cloud-sdk
+
+# and now stop being root
+USER gitpod

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,5 @@
+image:
+  file: .gitpod.Dockerfile
+
+tasks:
+  - init: make

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -2,4 +2,7 @@ image:
   file: .gitpod.Dockerfile
 
 tasks:
-  - init: make
+  - init: sudo docker-up
+  - init: gcloud auth login \
+        && gcloud config set project "$GOOGLE_CLOUD_PROJECT"
+

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -2,7 +2,12 @@ image:
   file: .gitpod.Dockerfile
 
 tasks:
-  - init: sudo docker-up
-  - init: gcloud auth login \
-        && gcloud config set project "$GOOGLE_CLOUD_PROJECT"
+  # always start docker
+  - command: sudo docker-up
 
+  # main init & run
+  - init: -|
+      gcloud auth login \
+        && ./service_account.sh \
+        && make
+    command: make run

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,9 @@ RUN mkdir -p /usr/local/gcloud \
 # Adding the package path to local
 ENV PATH $PATH:/usr/local/gcloud/google-cloud-sdk/bin
 
-# Working directory for gcloudrig-cloud-run
-WORKDIR /usr/src/app
+COPY ./api /usr/src/app/api/
+COPY ./service_account.json /secret/
+COPY ./entrypoint.sh /
 
 # Get tagged copy of gcloudrig
 RUN curl https://github.com/gcloudrig/gcloudrig/archive/v0.1.0-beta.3.tar.gz > /tmp/gcloudrig.tar.gz
@@ -24,14 +25,8 @@ RUN curl https://github.com/gcloudrig/gcloudrig/archive/v0.1.0-beta.3.tar.gz > /
 ARG project_id 
 ENV PROJECT_ID=$project_id
 
-# Hard-code service account key and set project (TEMPORARY SOLUTION)
-RUN gcloud auth activate-service-account --key-file ./service_account.json
-RUN gcloud config set project $PROJECT_ID
-
-# npm setup
 WORKDIR /usr/src/app/api
 RUN npm ci --only=production
 
-# make it so
-EXPOSE 8080
-CMD [ "node", "index.js" ]
+EXPOSE 5000/tcp
+CMD [ "sh", "-c", "/entrypoint.sh" ]

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 build:
-	docker build --build-arg project_id=massive-seer-267723 --tag gcloudrigapi .
+	docker build --build-arg project_id="${GOOGLE_CLOUD_PROJECT}" --tag gcloudrigapi .
 
 run_bash:
 	docker run -p 5000:5000 --env PORT=5000 --env JWT_SECRET=testing1234 --env API_USERNAME=test --env API_PASSWORD=password123 -it gcloudrigapi bash

--- a/README.md
+++ b/README.md
@@ -1,0 +1,2 @@
+[![Gitpod ready-to-code](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/gcloudrig/gcloudrig-cloud-run)
+

--- a/api/index.js
+++ b/api/index.js
@@ -31,7 +31,8 @@ app.use(express.static("public"));
 app.use(bodyParser.json());
 
 app.get("/", async (req, res) => {
-  //send angular app
+  // TODO: send angular app
+  res.status(200).send("hello there");
 });
 
 app.use("/v1/run", commandRoutes);

--- a/service_account.sh
+++ b/service_account.sh
@@ -14,10 +14,8 @@ if [ -z "$GOOGLE_CLOUD_PROJECT" ]; then
         echo "ERROR: \$GOOGLE_CLOUD_PROJECT environment variable is not set!"
         exit 1
     else
-        GOOGLE_CLOUD_PROJECT="$gcloud_config_project"
+        GOOGLE_CLOUD_PROJECT=$gcloud_config_project
     fi
-else
-    GOOGLE_CLOUD_PROJECT="$gcloud_config_project"
 fi
 
 # Create a new IAM service account

--- a/service_account.sh
+++ b/service_account.sh
@@ -1,10 +1,38 @@
+#!/usr/bin/env bash
+
+# ensure we're logged in to gcloud
+LOGGED_IN_USER=$(gcloud auth list --quiet --filter 'status=ACTIVE' --format 'value(account)' 2>/dev/null)
+if [ -z "$LOGGED_IN_USER" ]; then
+    echo "ERROR: Not logged in to gcloud; please run 'gcloud auth login'"
+    exit 1
+fi
+
+# ensure we have a project set (either through env var or via 'gcloudrig config set project')
+if [ -z "$GOOGLE_CLOUD_PROJECT" ]; then
+    gcloud_config_project=$(gcloud config get-value project --format 'value(.)')
+    if [ -z "$gcloud_config_project" ]; then
+        echo "ERROR: \$GOOGLE_CLOUD_PROJECT environment variable is not set!"
+        exit 1
+    else
+        GOOGLE_CLOUD_PROJECT="$gcloud_config_project"
+    fi
+else
+    GOOGLE_CLOUD_PROJECT="$gcloud_config_project"
+fi
+
+# Create a new IAM service account
 gcloud iam service-accounts create gcloudrigkey \
+    --project="$GOOGLE_CLOUD_PROJECT" \
     --description="gcloudrigkey for cloud run" \
     --display-name="gcloudrigkey"
 
-gcloud projects add-iam-policy-binding massive-seer-267723 \
-    --member="serviceAccount:gcloudrigkey@${project_id}.iam.gserviceaccount.com" \
+# Assign it the "roles/editor" role
+gcloud projects add-iam-policy-binding "$GOOGLE_CLOUD_PROJECT" \
+    --project="$GOOGLE_CLOUD_PROJECT" \
+    --member="serviceAccount:gcloudrigkey@$GOOGLE_CLOUD_PROJECT.iam.gserviceaccount.com" \
     --role="roles/editor"
 
+# Get a key for it and save it as "service_account.json"
 gcloud iam service-accounts keys create service_account.json \
-  --iam-account "gcloudrigkey@${project_id}.iam.gserviceaccount.com"
+    --project="$GOOGLE_CLOUD_PROJECT" \
+    --iam-account "gcloudrigkey@$GOOGLE_CLOUD_PROJECT.iam.gserviceaccount.com"


### PR DESCRIPTION
This commit implements a fully-automated development setup using Gitpod.io, an
online IDE for GitLab, GitHub, and Bitbucket that enables Dev-Environments-As-Code.
This makes it easy for anyone to get a ready-to-code workspace for any branch,
issue or pull request almost instantly with a single click.

TODO:
- include instructions for `sudo docker-up` (since docker support in gitpod is in beta)
- test out port configs
- test out gcloud auth
- do a trial build
- merge PR into [develop](/gcloudrig/gcloudrig-cloud-run/tree/develop)